### PR TITLE
Formally allow `url` in `DriverManager::getConnection()`

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -175,6 +175,7 @@ final class DriverManager
      *     replica?: array<OverrideParams>,
      *     sharding?: array<string,mixed>,
      *     slaves?: array<OverrideParams>,
+     *     url?: string,
      *     user?: string,
      *     wrapperClass?: class-string<T>,
      * } $params


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | (not reported)

#### Summary

Psalm complains when instantiating a Connection like this: `DriverManager::getConnection([ 'url' => 'mysql://user:pwd@host/db' ])`, because `url` is not explicitly allowed in `@psalm-param` phpdoc. Perhaps it was forgotten.